### PR TITLE
feat: store jwt on a cookie after login

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@nx/angular": "16.7.2",
         "bootstrap": "^5.3.1",
         "ngx-bootstrap": "^11.0.2",
+        "ngx-cookie-service": "^16.0.1",
         "ngx-toastr": "^17.0.2",
         "rxjs": "~7.8.0",
         "svg-to-ts": "^10.0.0",
@@ -13872,6 +13873,18 @@
         "@angular/core": "^16.0.0",
         "@angular/forms": "^16.0.0",
         "rxjs": "^6.5.3 || ^7.6.0"
+      }
+    },
+    "node_modules/ngx-cookie-service": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/ngx-cookie-service/-/ngx-cookie-service-16.0.1.tgz",
+      "integrity": "sha512-q8i5eX2b6SIIZcu9wy+lvOU65cLJhHD9EVz5TGGkKi8Y7X/aZbUyQ9U4CgNOfKDWtPUDFOMD8IW/cijoVKe59Q==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "^16.0.0",
+        "@angular/core": "^16.0.0"
       }
     },
     "node_modules/ngx-toastr": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@nx/angular": "16.7.2",
     "bootstrap": "^5.3.1",
     "ngx-bootstrap": "^11.0.2",
+    "ngx-cookie-service": "^16.0.1",
     "ngx-toastr": "^17.0.2",
     "rxjs": "~7.8.0",
     "svg-to-ts": "^10.0.0",

--- a/src/app/features/authentication/api/authentication.service.ts
+++ b/src/app/features/authentication/api/authentication.service.ts
@@ -3,6 +3,8 @@ import { HttpClient, HttpResponse } from '@angular/common/http';
 import { environment } from '../../../../environment/environment';
 import { User } from '../../../shared/models/user';
 import { Observable } from 'rxjs';
+import { LoginRequest } from '../models/login-request.model';
+import { LoginResponse } from '../models/login-response.model';
 
 @Injectable()
 export class AuthenticationService {
@@ -12,5 +14,9 @@ export class AuthenticationService {
 
   register(user: User): Observable<HttpResponse<any>> {
     return this.http.post<HttpResponse<any>>(`${this.baseApi}/signup`, user);
+  }
+
+  login(loginRequest: LoginRequest): Observable<LoginResponse> {
+    return this.http.post<LoginResponse>(`${this.baseApi}/login`, loginRequest);
   }
 }

--- a/src/app/features/authentication/authentication.facade.ts
+++ b/src/app/features/authentication/authentication.facade.ts
@@ -2,23 +2,44 @@ import { Injectable } from '@angular/core';
 import { AuthenticationService } from './api/authentication.service';
 import { AuthenticationState } from './state/authentication.state';
 import { User } from '../../shared/models/user';
+import { LoginRequest } from './models/login-request.model';
+import { CookieService } from 'ngx-cookie-service';
 
 @Injectable()
 export class AuthenticationFacade {
   constructor(
     private authenticationService: AuthenticationService,
-    private state: AuthenticationState
+    private state: AuthenticationState,
+    private cookieService: CookieService
   ) {}
 
   isRegistering$ = this.state.isRegistering$;
   isRegistered$ = this.state.isRegistered$;
   error$ = this.state.error$;
+  loginLoading$ = this.state.loginLoading$;
+  loginSuccess$ = this.state.loginSuccess$;
+  loginError$ = this.state.loginError$;
 
-  register(user: User) {
+  register(user: User): void {
     this.state.register();
     this.authenticationService.register(user).subscribe({
       next: () => this.state.finishRegister(),
       error: () => this.state.dispatchError(),
     });
+  }
+
+  login(loginRequest: LoginRequest): void {
+    this.state.login();
+    this.authenticationService.login(loginRequest).subscribe({
+      next: (loginResponse) => {
+        this.state.finishLogin();
+        this.setTokenCookie(loginResponse.authToken);
+      },
+      error: () => this.state.dispatchLoginError(),
+    });
+  }
+
+  private setTokenCookie(token: string): void {
+    this.cookieService.set('jwt', token);
   }
 }

--- a/src/app/features/authentication/authentication.module.ts
+++ b/src/app/features/authentication/authentication.module.ts
@@ -15,6 +15,7 @@ import { RegistrationComponent } from './containers/registration/registration.co
 import { AuthenticationFacade } from './authentication.facade';
 import { AuthenticationService } from './api/authentication.service';
 import { AuthenticationState } from './state/authentication.state';
+import { CookieService } from 'ngx-cookie-service';
 
 @NgModule({
   imports: [
@@ -27,7 +28,12 @@ import { AuthenticationState } from './state/authentication.state';
     MvfLoaderComponent,
   ],
   declarations: [LoginComponent, RegistrationComponent],
-  providers: [AuthenticationFacade, AuthenticationService, AuthenticationState],
+  providers: [
+    AuthenticationFacade,
+    AuthenticationService,
+    AuthenticationState,
+    CookieService,
+  ],
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
 export class AuthenticationModule {}

--- a/src/app/features/authentication/containers/login/login.component.html
+++ b/src/app/features/authentication/containers/login/login.component.html
@@ -22,9 +22,10 @@
             <div class="card-body py-5 px-4">
               <h2>Bem vindo de volta!</h2>
               <p>É um prazer ver você por aqui novamente.</p>
-              <form class="my-5">
+              <form class="my-5" [formGroup]="loginForm">
                 <div class="form-floating mb-3">
                   <input
+                    formControlName="email"
                     type="email"
                     class="form-control"
                     id="email"
@@ -34,6 +35,7 @@
                 </div>
                 <div class="form-floating mb-3">
                   <input
+                    formControlName="password"
                     type="password"
                     class="form-control"
                     id="password"
@@ -42,7 +44,11 @@
                   <label for="password">Senha</label>
                 </div>
 
-                <button class="btn btn-primary btn-lg w-100 mt-2">
+                <button
+                  class="btn btn-primary btn-lg w-100 mt-2"
+                  (click)="login()"
+                  [disabled]="loginForm.invalid"
+                >
                   Entrar
                 </button>
               </form>

--- a/src/app/features/authentication/containers/login/login.component.ts
+++ b/src/app/features/authentication/containers/login/login.component.ts
@@ -1,7 +1,60 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
+import { AuthenticationFacade } from '../../authentication.facade';
+import { ToastrService } from 'ngx-toastr';
+import { Observable } from 'rxjs';
+import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
+import { LoginRequest } from '../../models/login-request.model';
 
+@UntilDestroy()
 @Component({
   selector: 'mvf-auth-root',
   templateUrl: './login.component.html',
 })
-export class LoginComponent {}
+export class LoginComponent implements OnInit {
+  loginLoading$?: Observable<boolean>;
+  loginError$?: Observable<boolean>;
+  loginSuccess$?: Observable<boolean>;
+
+  loginForm = new FormGroup({
+    email: new FormControl('', {
+      validators: [Validators.required, Validators.email],
+      nonNullable: true,
+    }),
+    password: new FormControl('', {
+      validators: Validators.required,
+      nonNullable: true,
+    }),
+  });
+
+  constructor(
+    private facade: AuthenticationFacade,
+    private toastr: ToastrService
+  ) {}
+
+  ngOnInit(): void {
+    this.loginLoading$ = this.facade.loginLoading$;
+    this.loginSuccess$ = this.facade.loginSuccess$;
+    this.loginError$ = this.facade.loginError$;
+
+    this.loginError$
+      .pipe(untilDestroyed(this))
+      .subscribe((hasError) =>
+        hasError ? this.toastr.error('Email e/ou senha inválidos.') : null
+      );
+    this.loginSuccess$
+      .pipe(untilDestroyed(this))
+      .subscribe((success) =>
+        success ? this.toastr.success('Sucesso') : null
+      );
+  }
+
+  login(): void {
+    const loginData: LoginRequest = {
+      email: this.loginForm.controls.email.value,
+      password: this.loginForm.controls.password.value,
+    };
+
+    this.facade.login(loginData);
+  }
+}

--- a/src/app/features/authentication/models/login-request.model.ts
+++ b/src/app/features/authentication/models/login-request.model.ts
@@ -1,0 +1,4 @@
+export interface LoginRequest {
+  email: string;
+  password: string;
+}

--- a/src/app/features/authentication/models/login-response.model.ts
+++ b/src/app/features/authentication/models/login-response.model.ts
@@ -1,0 +1,3 @@
+export interface LoginResponse {
+  authToken: string;
+}

--- a/src/app/features/authentication/state/authentication.state.ts
+++ b/src/app/features/authentication/state/authentication.state.ts
@@ -1,11 +1,14 @@
 import { Injectable } from '@angular/core';
-import { BehaviorSubject, Observable } from 'rxjs';
+import { BehaviorSubject, Observable, Subject } from 'rxjs';
 
 @Injectable()
 export class AuthenticationState {
   private _isRegistering$ = new BehaviorSubject<boolean>(false);
   private _isRegistered$ = new BehaviorSubject<boolean>(false);
   private _error$ = new BehaviorSubject<boolean>(false);
+  private _loginLoading$ = new Subject<boolean>();
+  private _loginSuccess$ = new Subject<boolean>();
+  private _loginError$ = new Subject<boolean>();
 
   get isRegistering$(): Observable<boolean> {
     return this._isRegistering$.asObservable();
@@ -17,6 +20,18 @@ export class AuthenticationState {
 
   get error$(): Observable<boolean> {
     return this._error$.asObservable();
+  }
+
+  get loginLoading$(): Observable<boolean> {
+    return this._loginLoading$.asObservable();
+  }
+
+  get loginSuccess$(): Observable<boolean> {
+    return this._loginSuccess$.asObservable();
+  }
+
+  get loginError$(): Observable<boolean> {
+    return this._loginError$.asObservable();
   }
 
   register(): void {
@@ -31,5 +46,21 @@ export class AuthenticationState {
   dispatchError(): void {
     this._error$.next(true);
     this._isRegistering$.next(false);
+  }
+
+  login(): void {
+    this._loginLoading$.next(true);
+  }
+
+  finishLogin(): void {
+    this._loginLoading$.next(false);
+    this._loginError$.next(false);
+    this._loginSuccess$.next(true);
+  }
+
+  dispatchLoginError(): void {
+    this._loginError$.next(true);
+    this._loginLoading$.next(false);
+    this._loginSuccess$.next(false);
   }
 }


### PR DESCRIPTION
This PR stores the JWT (auth token) on a cookie on the user's browser to use for the next requests